### PR TITLE
Error handling

### DIFF
--- a/mutils_panoptic/MuTILsInference.py
+++ b/mutils_panoptic/MuTILsInference.py
@@ -363,8 +363,12 @@ class ROIPostProcessor:
             roi: InferenceResult = self.postprocess_queue.get()
             if roi is None:
                 break
-            self.run_roi(roi)
-            self.logger.info(f"Completed ROI {roi.number} by {roi.model}.")
+            try:
+                self.run_roi(roi)
+                self.logger.info(f"Completed ROI {roi.number} by {roi.model}.")
+            except Exception as e:
+                self.logger.error(f"Error processing ROI {roi.number}: {e}")
+                continue
 
     def run_roi(self, roi: InferenceResult) -> None:
         """Run postprocessing for the ROI.

--- a/mutils_panoptic/MuTILsInference.py
+++ b/mutils_panoptic/MuTILsInference.py
@@ -259,21 +259,26 @@ class ROIInferenceProcessor:
             if roi is None:
                 self.put(end_signal=True)
                 break
-            result = self.inference(roi)
-            roi.to_cpu()
-            self.inference_result = InferenceResult(
-                number=roi.number,
-                coords=roi.coords,
-                name=roi.name,
-                model=roi.model,
-                batch=roi.batch,
-                hres_ignore=roi.hres_ignore,
-                img=roi.img,
-                result=result,
-            )
-            self.inference_result.to_cpu()
-            torch.cuda.empty_cache()
-            self.put()
+            try:
+                result = self.inference(roi)
+                roi.to_cpu()
+                self.inference_result = InferenceResult(
+                    number=roi.number,
+                    coords=roi.coords,
+                    name=roi.name,
+                    model=roi.model,
+                    batch=roi.batch,
+                    hres_ignore=roi.hres_ignore,
+                    img=roi.img,
+                    result=result,
+                )
+                self.inference_result.to_cpu()
+                torch.cuda.empty_cache()
+                self.put()
+            except Exception as e:
+                # TODO: record error in the log file
+                print(f"Error processing ROI: {e}")
+                continue
 
     def inference(self, roi: ROI):
 

--- a/mutils_panoptic/MuTILsInference.py
+++ b/mutils_panoptic/MuTILsInference.py
@@ -135,8 +135,13 @@ class ROIPreProcessor:
     def run(self):
         """Loop through one chunk."""
         for single_roi in self.roi_chunk:
-            self.run_roi(single_roi)
-            self.inference_queue.put(self.roi)
+            try:
+                roi = self.run_roi(single_roi)
+                self.inference_queue.put(roi)
+            except Exception as e:
+                # TODO: record error in the log file
+                print(f"Error processing ROI: {e}")
+                continue
 
     def run_roi(self, single_roi: tuple):
         """Run the preprocessing for one ROI."""
@@ -160,6 +165,8 @@ class ROIPreProcessor:
             tile_size=(self.roi_side_hres, self.roi_side_hres),
         )
         self._provide_input(tile=tile)
+
+        return self.roi
 
     def _get_roi_coords(self, roi_number: int) -> list:
         """Get the coordinates of the ROI."""

--- a/mutils_panoptic/MuTILsWSIRunner.py
+++ b/mutils_panoptic/MuTILsWSIRunner.py
@@ -1319,8 +1319,14 @@ if __name__ == "__main__":
         config.logger.info(f"*** {slmonitor} ***")
         config.logger.info(f"")
 
-        # Run a slide
-        runner.run_slide(slmonitor, slide)
+        try:
+            runner.run_slide(slmonitor, slide)
+        except Exception as e:
+            config.logger.error(
+                f"Error processing slide {slide.name}: {e}", exc_info=True
+            )
+            config.logger.info("Skipping to the next slide...")
+        continue
 
     end = time.time()
 

--- a/mutils_panoptic/MuTILsWSIRunner.py
+++ b/mutils_panoptic/MuTILsWSIRunner.py
@@ -78,11 +78,8 @@ class ProcessManager:
         params : dict
             A dictionary containing the configuration parameters for preprocessing.
         """
-        assert (
-            len(roi_chunks) == self.N_preproc
-        ), f"Number of chunks must match number of processes."
 
-        for i in range(self.N_preproc):
+        for i in range(len(roi_chunks)):
             roi_chunk = roi_chunks[i]
             # Each chunk has a model assigned to it and each model has its queue.
             # Pass the right chunk - queue pair to the process:
@@ -655,28 +652,35 @@ class MuTILsWSIRunner:
             number and the model name.
         """
 
-        assert self.N_preprocesses % 5 == 0, (
-            "Number of CPUs must be divisible by 5. "
-            "This is to ensure that each model gets at least one chunk."
-        )
+        roi_pairs = [(roi, model) for model, rois in model_rois.items() for roi in rois]
 
-        chunk_fraction = (
-            self.N_preprocesses / 5
-        )  # number of chunks to split each model's rois into
+        total_rois = len(roi_pairs)
+        if total_rois == 0:
+            return []
+
+        # Calculate how many chunks each model should get (proportional to ROI count)
+        model_counts = {model: len(rois) for model, rois in model_rois.items()}
+        model_chunks = {
+            model: max(1, int(round(self.N_preprocesses * (count / total_rois))))
+            for model, count in model_counts.items()
+        }
+
+        # Reduce one chunk from the largest model if too many chunks were assigned
+        while sum(model_chunks.values()) > min(self.N_preprocesses, total_rois):
+            max_model = max(model_chunks, key=model_chunks.get)
+            model_chunks[max_model] -= 1
+
         roi_chunks = []
-        for k, v in model_rois.items():
-            chunked = np.array_split(v, chunk_fraction)
-            for c in chunked:
-                nested_chunk = [(int(item), k) for item in c.tolist()]
-                roi_chunks.append(nested_chunk)
 
-        # Check if all elemnts of the chunk are assigned to the same model
-        check_model_consistency = [
-            all([roi[1] == chunk[0][1] for roi in chunk]) for chunk in roi_chunks
-        ]
-        assert all(
-            check_model_consistency
-        ), "All elements of the chunk must be assigned to the same model."
+        for model, rois in model_rois.items():
+            n_chunks = model_chunks.get(model, 0)
+            if not rois or n_chunks == 0:
+                continue
+            split = np.array_split(rois, n_chunks)
+            for part in split:
+                chunk = [(roi, model) for roi in part.tolist()]
+                if chunk:
+                    roi_chunks.append(chunk)
 
         return roi_chunks
 


### PR DESCRIPTION
This pull request has minor fixes for error handing at both ROI and slide level. These fixes allow MuTILs to skip failed ROI-s or even slides if an error happens.

_split_to_chunks() method has been also rewritten to generate more evenly distributed chunks of ROI-s and it also manages edge cases where there are less ROI-s than processes. 