### PR TITLE
Distribute models on GPUs based on available VRAM

### DIFF
--- a/mutils_panoptic/MuTILsInference.py
+++ b/mutils_panoptic/MuTILsInference.py
@@ -243,12 +243,10 @@ class ROIPreProcessor:
 class ROIInferenceProcessor:
     def __init__(
         self,
-        gpu_id: int,
         inference_queue: mp.Queue,
         postprocess_queue: mp.Queue,
         model: dict,
     ):
-        self.gpu_id = gpu_id
         self.inference_queue = inference_queue
         self.postprocess_queue = postprocess_queue
         self.model = model
@@ -282,7 +280,7 @@ class ROIInferenceProcessor:
 
     def inference(self, roi: ROI):
 
-        device = f"cuda:{self.gpu_id}" if torch.cuda.is_available() else "cpu"
+        device = f"cuda:{self.model['device']}" if torch.cuda.is_available() else "cpu"
 
         highres_rgb = torch.as_tensor(
             roi.batch.highres_rgb, dtype=torch.float32, device=device


### PR DESCRIPTION
The pull request has the following changes:

   1. The GPU checking method has been updated to assign the 5 model folds to the minimum number of GPU devices that have sufficient VRAM. The required VRAM is 8GB per model. Four scenarios have been implemented:
         - all 5 models are put on a single GPU (VRAM > 40GB)
         - 3 models are put on the first GPU and 2 models are put on the second GPU
         - 2 models are put on the first and second GPU and 1 model is put on the third GPU
         - all 5 models are put on 5 separate GPUs (VRAM < 16GB)